### PR TITLE
chore: use https links for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gatsby Plugin Disqus  
 
 <p align="right">
-  <a href="https://npmjs.org/package/gatsby-plugin-disqus"><img src="http://img.shields.io/npm/v/gatsby-plugin-disqus.svg" alt="npm version" /></a>
+  <a href="https://npmjs.org/package/gatsby-plugin-disqus"><img src="https://img.shields.io/npm/v/gatsby-plugin-disqus.svg" alt="npm version" /></a>
 </p>
 
 A plugin that simplifies the process of integrating [Disqus](https://disqus.com/) comments within your [Gatsby](https://www.gatsbyjs.org/) website.


### PR DESCRIPTION
We deploy these READMEs to gatsbyjs.org and Netlify annoyingly warns on insecure content (e.g. an http link on an otherwise https site).

Would appreciate a merge--thank you!