### PR TITLE
Remove unnecessary stylesheet

### DIFF
--- a/src/components/Disqus.jsx
+++ b/src/components/Disqus.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { insertScript, removeScript, shallowComparison } from '../utils'
-import "../style.css"
 
 export default class Disqus extends React.Component {
   

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,0 @@
-#disqus_thread {
-  width: 95%;
-  margin: auto;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes the stylesheet that provided a default `width` and `margin` formatting for the `Disqus.jsx` component, as this could potentially conflict with users that want to override these styles.

## Description
<!--- Describe your changes in detail -->
Removed `src/style.css` and related import

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The minimal styling could unexpectedly conflict with user's own `width` and `margin` styles.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with example Gatsby blog.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING.md**](./docs/CONTRIBUTING.md) document.
- [X] All new and existing tests passed.
