### PR TITLE
Add language config prop (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ export default PostTemplate
 ```
 
 While providing a `url`, `identifier`, and `title` are optional, these attributes are recommended as it will prevent threads from being lost in the case that the domain changes or the post is renamed.
+Additional information on all available parameters can be found on the [wiki](https://github.com/tterb/gatsby-plugin-disqus/wiki/Configure#parameters).
 
 ## Contributing  
 

--- a/src/components/Disqus.jsx
+++ b/src/components/Disqus.jsx
@@ -13,7 +13,8 @@ export default class Disqus extends React.Component {
       this.config = {
         identifier: props.identifier,
         url: props.url,
-        title: props.title
+        title: props.title,
+        language: props.language,
       }
     }
   }
@@ -43,6 +44,7 @@ export default class Disqus extends React.Component {
         this.page.identifier = config.identifier
         this.page.title = config.title
         this.page.url = config.url
+        this.language = config.language
       }
       insertScript(`https://${this.shortname}.disqus.com/embed.js`,
                    'disqus-embed-script', window.document.body)
@@ -95,8 +97,17 @@ Disqus.propTypes = {
      * (If undefined, Disqus will use the global.location.href)
      */
     url: PropTypes.string,
+    /*
+     * Tells the Disqus service to override the default site language for the
+     * current page.
+     * This allows for dynamically loading the Disqus embed in different 
+     * languages on a per-page basis.
+     * (If undefined, Disqus will use the default site language)
+     */
+    language: PropTypes.string,
   }),
   identifier: PropTypes.string,
   title: PropTypes.string,
   url: PropTypes.string,
+  language: PropTypes.string,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added an optional `language` parameter to allow sites to dynamically specify languages on a per-page basis.
Additional usage information for this parameter can be found here: [Multi-lingual websites | Disqus](https://help.disqus.com/en/articles/1717203-multi-lingual-websites)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #10 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Gatsby test website.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](./docs/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tterb/gatsby-plugin-disqus/11)
<!-- Reviewable:end -->
