### PR TITLE
Moved cross-env and babel-preset-gatsby-package to devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
-    "prop-types": "^15.6.2"
-  },
-  "dependencies": {
     "babel-preset-gatsby-package": "^0.1.2",
+    "prop-types": "^15.6.2",
     "cross-env": "^5.2.0"
+  },
+  "dependencies": {    
   },
   "peerDependencies": {
     "react": "^16.8.5"


### PR DESCRIPTION
I saw these showing up in my dependencies. I believe these should belong in devDependencies instead of dependencies.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Moved cross-env and babel-preset-gatsby-package to devdependencies

## Motivation and Context
Less dependencies. Also see the examples:
https://www.npmjs.com/package/cross-env#installation
https://www.npmjs.com/package/babel-preset-gatsby-package#usage