### PR TITLE
Modify Probot `stale` config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 40
+daysUntilStale: 20
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
@@ -14,7 +14,8 @@ onlyLabels: []
 exemptLabels:
   - pinned
   - security
-  - "[Status] Maybe Later"
+  - help wanted
+  - confirmed
   - "[WIP]"
 
 # Set to true to ignore issues in a project (defaults to false)
@@ -31,8 +32,7 @@ staleLabel: :ghost: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
+  This issue has been automatically marked as stale because it appears to have gone quiet. It will be closed in 7 days if no further activity occurs. Thank you
   for your contributions.
 
 # Comment to post when removing the stale label.
@@ -50,14 +50,8 @@ limitPerRun: 30
 # only: issues
 
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
-# pulls:
-#   daysUntilStale: 30
-#   markComment: >
-#     This pull request has been automatically marked as stale because it has not had
-#     recent activity. It will be closed if no further activity occurs. Thank you
-#     for your contributions.
-
-issues:
-  exemptLabels:
-    - help wanted
-    - not stale
+pulls:
+  daysUntilStale: 40
+  markComment: >
+    This pull request has been automatically marked as stale because it appears to have gone quiet. It will be closed in 7 days if no further activity occurs. Thank you
+    for your contributions.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modified the `daysUntilStale`, `exemptLabels`, and `markComment` for issues and pull-requests that Probot will mark as stale.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Probot was currently configured to wait too long for issues to be marked as stale and ignore pull-requests. Additionally, the `markComments` didn't include the timeframe in which they would be closed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](./docs/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.
