### PR TITLE
Modify Disqus component to use DISQUS.reset()

### DIFF
--- a/src/components/CommentCount.jsx
+++ b/src/components/CommentCount.jsx
@@ -29,6 +29,10 @@ export default class CommentCount extends React.Component {
     this.loadInstance()
   }
 
+  componentWillUnmount() {
+    this.cleanInstance()
+  }
+
   loadInstance() {
     if(window.document.getElementById('dsq-count-scr')) {
       queueResetCount()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
  * Modified the `Disqus` component to better utilize `DISQUS.reset()` rather than removing and adding the script to reload.
  * Modified the `cleanInstance()` functions of the `Disqus` and `CommentCount` components to improve cleanup on unmount

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #28 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using local test site

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING.md**](./docs/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tterb/gatsby-plugin-disqus/29)
<!-- Reviewable:end -->
